### PR TITLE
Don't apply possessive to empty strings

### DIFF
--- a/lib/possessive.rb
+++ b/lib/possessive.rb
@@ -2,6 +2,7 @@
 
 String.class_eval do
   def possessive
+    return self if self.empty?
     self + ('s' == self[-1,1] ? Possessive::APOSTROPHE_CHAR : Possessive::APOSTROPHE_CHAR+"s")
   end
 end

--- a/test/test_possessive.rb
+++ b/test/test_possessive.rb
@@ -10,4 +10,8 @@ class TestPossessive < Test::Unit::TestCase
   test "Possessive with a string ending with s" do
     assert_equal "Steelers’", "Steelers".possessive
   end
+
+  test "Possessive with an empty string" do
+    assert_equal "", "".possessive
+  end
 end


### PR DESCRIPTION
Preventing possessive from being applied to an empty string as per Issue #4,

```
"".possessive  #  "" instead of "'s"
```
